### PR TITLE
clear cached "actionsById" on ActionTypes.COMMIT

### DIFF
--- a/src/instrument.js
+++ b/src/instrument.js
@@ -217,6 +217,7 @@ function liftReducerWith(reducer, initialCommittedState, monitorReducer, options
         // Consider the last committed state the new starting point.
         // Squash any staged actions into a single committed state.
         actionsById = { 0: liftAction(INIT_ACTION) };
+        initialLiftedState.actionsById = actionsById;
         nextActionId = 1;
         stagedActionIds = [0];
         skippedActionIds = [];


### PR DESCRIPTION
Committing creates a clean slate, however `initialLiftedState.actionsById` is left with old actions leaving an unnecessary memory footprint
