### PR TITLE
Support Redux 4 in peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
   "peerDependencies": {
     "react": "^0.14.9 || ^15.3.0 || ^16.0.0",
     "react-redux": "^4.0.0 || ^5.0.0",
-    "redux": "^3.5.2"
+    "redux": "^3.5.2 || ^4.0.0"
   },
   "dependencies": {
     "prop-types": "^15.5.7",


### PR DESCRIPTION
See #399. The tests appear to work and if I update the other peerDependencies I can get it to install production dependencies without warning. I'm assuming Redux 4 doesn't break anything since the extension still works for me and the tests pass.