### PR TITLE
Include Typings in package and fix missing instrument options

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,3 +1,4 @@
+// Redux version 4.0.0
 // Type definitions for redux-devtools 3.4.1
 // TypeScript Version: 2.8.1
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -7,14 +7,12 @@ import { StoreEnhancer } from "redux";
 
 export interface DevTools {
   new (): JSX.ElementClass;
-  instrument(opts?: any): StoreEnhancer<any>;
+  instrument(opts?: any): StoreEnhancer;
 }
 
 export declare function createDevTools(el: React.ReactElement<any>): DevTools;
-export declare function persistState(
-  debugSessionKey: string
-): StoreEnhancer<any>;
+export declare function persistState(debugSessionKey: string): StoreEnhancer;
 
-declare const factory: { instrument(opts?: any): () => StoreEnhancer<any> };
+declare const factory: { instrument(opts?: any): () => StoreEnhancer };
 
 export default factory;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,19 @@
+// Type definitions for redux-devtools 3.4.1
+// TypeScript Version: 2.8.1
+
+import * as React from "react";
+import { StoreEnhancer } from "redux";
+
+export interface DevTools {
+  new (): JSX.ElementClass;
+  instrument(opts?: any): StoreEnhancer<any>;
+}
+
+export declare function createDevTools(el: React.ReactElement<any>): DevTools;
+export declare function persistState(
+  debugSessionKey: string
+): StoreEnhancer<any>;
+
+declare const factory: { instrument(opts?: any): () => StoreEnhancer<any> };
+
+export default factory;


### PR DESCRIPTION
So right now typescript users are presented with an error when trying to specify instrument options in the typings.

DefinetlyTyped is also an obsolete monolithic mess and splits away typing concerns from projects making type safety a second class citizen for most libs.

This pull request attempts to address both these issues.

Note that the typings work for redux v4.0.0 and subsequently may not be appropriate to publish as of yet.

I can always downgrade these typings to match the current DT typings and just include the missing options.

Thanks!