### PR TITLE
Upgrade to React 16.4 for trace-monitor and test-generator

### DIFF
--- a/packages/redux-devtools-test-generator/package.json
+++ b/packages/redux-devtools-test-generator/package.json
@@ -62,7 +62,7 @@
     "lodash.shuffle": "^4.2.0",
     "nyan-progress-webpack-plugin": "^1.1.4",
     "react-addons-test-utils": "^15.1.0",
-    "react-dom": "^15.1.0",
+    "react-dom": "^16.4.0",
     "react-redux": "^5.0.2",
     "react-router": "^3.0.2",
     "react-router-redux": "^4.0.8",
@@ -84,7 +84,7 @@
     "jsan": "^3.1.3",
     "object-path": "^0.11.1",
     "prop-types": "^15.5.10",
-    "react": "^15.1.0",
+    "react": "^16.4.0",
     "react-icons": "^2.2.3",
     "simple-diff": "^1.3.0"
   }

--- a/packages/redux-devtools-test-generator/test/__snapshots__/TestGenerator.spec.js.snap
+++ b/packages/redux-devtools-test-generator/test/__snapshots__/TestGenerator.spec.js.snap
@@ -2,13 +2,13 @@
 
 exports[`TestGenerator component should be empty when no actions provided 1`] = `
 <textarea
-  style="padding:10px;width:100%;height:100%;"
+  style="padding:10px;width:100%;height:100%"
 />
 `;
 
 exports[`TestGenerator component should generate test for the last action when selectedActionId not specified 1`] = `
 <textarea
-  style="padding:10px;width:100%;height:100%;"
+  style="padding:10px;width:100%;height:100%"
 >
   import expect from 'expect';
 import reducers from '../../reducers';
@@ -26,7 +26,7 @@ expect(state).toEqual({counter:1});
 
 exports[`TestGenerator component should generate test for vanilla js class 1`] = `
 <textarea
-  style="padding:10px;width:100%;height:100%;"
+  style="padding:10px;width:100%;height:100%"
 >
   import expect from 'expect';
 import SomeStore from '../../stores/SomeStore';
@@ -44,7 +44,7 @@ expect(store.counter).toEqual(1);
 
 exports[`TestGenerator component should generate test for vanilla js class with string template 1`] = `
 <textarea
-  style="padding:10px;width:100%;height:100%;"
+  style="padding:10px;width:100%;height:100%"
 >
   import expect from 'expect';
 import SomeStore from '../../stores/SomeStore';
@@ -62,7 +62,7 @@ describe('SomeStore', () =&gt; {
 
 exports[`TestGenerator component should match function template's test for first action 1`] = `
 <textarea
-  style="padding:10px;width:100%;height:100%;"
+  style="padding:10px;width:100%;height:100%"
 >
   import expect from 'expect';
 import reducers from '../../reducers';
@@ -80,7 +80,7 @@ expect(state).toEqual({counter:1});
 
 exports[`TestGenerator component should match string template's test for first action 1`] = `
 <textarea
-  style="padding:10px;width:100%;height:100%;"
+  style="padding:10px;width:100%;height:100%"
 >
   import expect from 'expect';
 import reducers from '../../reducers';
@@ -98,6 +98,6 @@ describe('reducers', () =&gt; {
 
 exports[`TestGenerator component should show warning message when no params provided 1`] = `
 <textarea
-  style="padding:10px;width:100%;height:100%;"
+  style="padding:10px;width:100%;height:100%"
 />
 `;

--- a/packages/redux-devtools-trace-monitor/package.json
+++ b/packages/redux-devtools-trace-monitor/package.json
@@ -38,7 +38,7 @@
     "babel-register": "^6.11.6",
     "babel-runtime": "^6.23.0",
     "enzyme": "^3.0.0",
-    "enzyme-adapter-react-15": "1.2.0",
+    "enzyme-adapter-react-16": "1.7.1",
     "enzyme-to-json": "^3.3.0",
     "eslint": "^5.0.0",
     "eslint-plugin-flowtype": "3.2.0",
@@ -47,8 +47,8 @@
     "eslint-plugin-react": "7.4.0",
     "jest": "^23.6.0",
     "react-addons-test-utils": "^15.4.0",
-    "react-dom": "^15.4.0",
-    "react-test-renderer": "^15.3.2",
+    "react-dom": "^16.4.0",
+    "react-test-renderer": "^16.4.0",
     "rimraf": "^2.5.2"
   },
   "dependencies": {
@@ -56,7 +56,7 @@
     "anser": "^1.4.7",
     "chalk": "^2.4.1",
     "html-entities": "^1.2.1",
-    "react": "^15.4.0",
+    "react": "^16.4.0",
     "redux-devtools-themes": "^1.0.0",
     "settle-promise": "^1.0.0"
   }

--- a/packages/redux-devtools-trace-monitor/test/StackTraceTab.spec.js
+++ b/packages/redux-devtools-trace-monitor/test/StackTraceTab.spec.js
@@ -3,7 +3,7 @@ import { configure, mount } from 'enzyme';
 import toJson from 'enzyme-to-json';
 import StackTraceTab from '../src/StackTraceTab';
 
-import Adapter from 'enzyme-adapter-react-15';
+import Adapter from 'enzyme-adapter-react-16';
 configure({ adapter: new Adapter() });
 
 function genAsyncSnapshot(component, done) {


### PR DESCRIPTION
There was a clash dependencies with the recent merge of the monorepo, I was not able to launch the `redux-devtools-inspector`, an [error caused](https://github.com/facebook/react/issues/10320) by the two repos `trace-monitor` and `test-generator` because there was an old version for React.

The fact to upgrade React to `v16.4` seems to resolve the problem.