### PR TITLE
[redux-devtools-trace-monitor] StackTraceTab: Allow custom `openFile` function

### DIFF
--- a/packages/redux-devtools-trace-monitor/src/StackTraceTab.js
+++ b/packages/redux-devtools-trace-monitor/src/StackTraceTab.js
@@ -7,6 +7,9 @@ import openFile from './openFile';
 const rootStyle = {padding: '5px 10px'};
 
 export default class StackTraceTab extends Component {
+  static defaultProps = {
+    openFile
+  }
   constructor(props) {
     super(props);
 
@@ -78,7 +81,7 @@ export default class StackTraceTab extends Component {
         const originalStackFrame = parsedFramesNoSourcemaps[frameIndex];
         console.log("Original stack frame: ", originalStackFrame);
         */
-        openFile(fileName, lineNumber, matchingStackFrame);
+        this.props.openFile(fileName, lineNumber, matchingStackFrame);
       }
     }
   }

--- a/packages/redux-devtools-trace-monitor/test/__snapshots__/StackTraceTab.spec.js.snap
+++ b/packages/redux-devtools-trace-monitor/test/__snapshots__/StackTraceTab.spec.js.snap
@@ -33,6 +33,7 @@ exports[`StackTraceTab component should render the link to docs 1`] = `
       },
     }
   }
+  openFile={[Function]}
 >
   <div
     style={
@@ -54,7 +55,9 @@ exports[`StackTraceTab component should render the link to docs 1`] = `
 `;
 
 exports[`StackTraceTab component should render with no props 1`] = `
-<StackTraceTab>
+<StackTraceTab
+  openFile={[Function]}
+>
   <div
     style={
       Object {
@@ -116,6 +119,7 @@ exports[`StackTraceTab component should render with props, but without stack 1`]
       },
     }
   }
+  openFile={[Function]}
 >
   <div
     style={
@@ -178,6 +182,7 @@ exports[`StackTraceTab component should render with trace stack 1`] = `
       },
     }
   }
+  openFile={[Function]}
 >
   <div
     style={


### PR DESCRIPTION
I'm trying to integrate the trace feature in [react-native-debugger](https://github.com/jhen0409/react-native-debugger/pull/301), and I think it also would be helpful in standalone app of [remotedev-app](https://github.com/zalmoxisus/remotedev-app/blob/master/src/app/containers/monitors/InspectorWrapper/index.js).

For follow-up work, we need make some changes in `remotedev-app`.