### PR TITLE
[react-json-tree] Add keyPath to getItemString args

### DIFF
--- a/packages/react-json-tree/README.md
+++ b/packages/react-json-tree/README.md
@@ -102,14 +102,14 @@ You can pass `getItemString` to customize the way arrays, objects, and iterable 
 By default, it'll be:
 
 ```jsx
-<JSONTree getItemString={(type, data, itemType, itemString)
+<JSONTree getItemString={(type, data, itemType, itemString, keyPath)
   => <span>{itemType} {itemString}</span>}
 ```
 
 But if you pass the following:
 
 ```jsx
-const getItemString = (type, data, itemType, itemString)
+const getItemString = (type, data, itemType, itemString, keyPath)
   => (<span> // {type}</span>);
 ```
 

--- a/packages/react-json-tree/src/JSONNestedNode.js
+++ b/packages/react-json-tree/src/JSONNestedNode.js
@@ -157,7 +157,8 @@ export default class JSONNestedNode extends React.Component {
       nodeType,
       data,
       itemType,
-      createItemString(data, collectionLimit)
+      createItemString(data, collectionLimit),
+      keyPath
     );
     const stylingArgs = [keyPath, nodeType, expanded, expandable];
 


### PR DESCRIPTION
Hi! I need to show custom itemType, which i had in another json object. So, I propose to add the full path to `getItemString` similarly as in `labelRenderer`