### PR TITLE
Allow custom keys for slider monitor

### DIFF
--- a/packages/redux-slider-monitor/README.md
+++ b/packages/redux-slider-monitor/README.md
@@ -43,6 +43,8 @@ Pass the `keyboardEnabled` prop to use these shortcuts
 
 `ctrl+]`: step forward
 
+You can override these shortcuts with the `playKey`, `stepBackwardKey`, and `stepForwardKey` respectively. These props are parsed by [parse-key](https://github.com/thlorenz/parse-key), just like in `DockMonitor`.
+
 ### Running Examples
 
 You can do this:

--- a/packages/redux-slider-monitor/package.json
+++ b/packages/redux-slider-monitor/package.json
@@ -45,6 +45,7 @@
   },
   "dependencies": {
     "devui": "^1.0.0-3",
+    "parse-key": "^0.2.1",
     "prop-types": "^15.5.8",
     "redux-devtools-themes": "^1.0.0"
   }


### PR DESCRIPTION
This is mostly lifted from [redux-devtools-dock-monitor](https://github.com/gaearon/redux-devtools-dock-monitor/blob/848eb32dd7b76db0b8d191bb447d39bc6376af59/src/DockMonitor.js#L67-L113), but there was some extra complexity around the fact that the underlying parse-key library doesn't support ctrl-[ and ctrl-]. Ideally, I would have defaulted the new props to the default bindings, but I had to settle for falling back to original logic when they are unset.

I couldn't get the example todomvc project running, but I was able to verify these changes in my own project, both with and without the new props.

Closes #471.