### PR TITLE
[redux-devtools-inspector]: filter - use '!' to negate query

### DIFF
--- a/packages/redux-devtools-inspector/src/ActionList.jsx
+++ b/packages/redux-devtools-inspector/src/ActionList.jsx
@@ -94,13 +94,19 @@ export default class ActionList extends Component {
       onJumpToState
     } = this.props;
     const lowerSearchValue = searchValue && searchValue.toLowerCase();
-    const filteredActionIds = searchValue
-      ? actionIds.filter(
-          id =>
-            actions[id].action.type.toLowerCase().indexOf(lowerSearchValue) !==
-            -1
-        )
-      : actionIds;
+
+    const shouldMatchNegative = lowerSearchValue && lowerSearchValue.indexOf('!') === 0;
+    const query = shouldMatchNegative ? lowerSearchValue.substring(1) : lowerSearchValue;
+
+    const filterFunction = id => {
+      const actionIndex = actions[id].action.type.toLowerCase().indexOf(query);
+      if (shouldMatchNegative) {
+        return actionIndex === -1;
+      }
+      return actionIndex !== -1;
+    };
+
+    const filteredActionIds = searchValue ? actionIds.filter(filterFunction) : actionIds;
 
     return (
       <div


### PR DESCRIPTION
**The problem:**
When using the devtools, I missed the functionality to filter by _not matching_ query, e.g. to just show actions which are not of certain type, to reduce clutter when debugging.

**The solution:**
This initial implementation proposes `!` prefix as a way to negate a query. So `!ADD` would filter _out_ any actions that contain the word `ADD` in their type.

**Problem with the solution**
The only drawbacks I see now are:
1. discoverability - this would of course be documented, but maybe a button would be a better solution from a UX perspective? 
2. actions with `!` as first character of `type`. This is probably a super edge-case, but maybe that would be a problem for someone.

Let me know what you think, I'd be happy to work more on that feature (docs, tests, etc)!