### PR TITLE
[react-json-tree] Mark deprecated React lifecycle methods as unsafe

### DIFF
--- a/packages/react-json-tree/src/JSONNestedNode.js
+++ b/packages/react-json-tree/src/JSONNestedNode.js
@@ -109,7 +109,7 @@ export default class JSONNestedNode extends React.Component {
     this.state = getStateFromProps(props);
   }
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     const nextState = getStateFromProps(nextProps);
     if (getStateFromProps(this.props).expanded !== nextState.expanded) {
       this.setState(nextState);

--- a/packages/react-json-tree/src/index.js
+++ b/packages/react-json-tree/src/index.js
@@ -110,7 +110,7 @@ export default class JSONTree extends React.Component {
     this.state = getStateFromProps(props);
   }
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     if (['theme', 'invertTheme'].find(k => nextProps[k] !== this.props[k])) {
       this.setState(getStateFromProps(nextProps));
     }


### PR DESCRIPTION
This will allow this package to be updated to React 17. For more information, see: https://reactjs.org/docs/react-component.html#unsafe_componentwillreceiveprops

### Fixes: https://github.com/reduxjs/redux-devtools/issues/480