### PR TITLE
Added ability to display function name as actionType

### DIFF
--- a/packages/redux-devtools-inspector/src/ActionListRow.jsx
+++ b/packages/redux-devtools-inspector/src/ActionListRow.jsx
@@ -76,7 +76,11 @@ export default class ActionListRow extends Component {
             isSkipped && 'actionListItemNameSkipped'
           ])}
         >
-          {actionType}
+          {
+            typeof actionType === 'function'
+            ? actionType.name
+            : actionType
+          }
         </div>
         {hideActionButtons ? (
           <RightSlider styling={styling} shown>


### PR DESCRIPTION
## Reason
This PR seeks to start the process of change. If the official Redux-devtools supports action types that aren't strings, then other libraries and utilities (which may already have no preference) will follow suit.

## Abstract
The normal advice is that `actionType` should be a string. This is purely for debugging purposes. If the tools used for debugging were altered, then it would be easier to use something other than a string.

Using a function means you don't have to have a separate action variable from the action creator itself:
```js
const someActionCreator = () => ({
  type: someActionCreator,
})
```

Redux doesn't care if your action type is a string, object, symbol or whatever. Even @gaearon noted it should be a Symbol for uniqueness, but only said to use strings because of the debugging potential.

Another benefit of using functions is you're only comparing memory references rather than strings. This is a performance boost, but probably not one that will manifest in most applications.

We could even take this further to include `symbol.description` and `classInstance.constructor.name`.

## Downfalls
The one downfall is most Redux tooling both utilizes and expects strings. This would need to change. Even `createReducer` would need to take a `Map` of actions instead of an `Object` or this wouldn't work.

## Alternatives
Without making a change to Redux-devtools, we could instead rely on using:
```js
const someActionCreator = () => ({
  type: someActionCreator.name,
})
```

This requires knowing certain action types are functions rather than strings. In an application where you might be iteratively updating action types, this would pose a problem.
