### PR TITLE
Extends search filters to add cumulative terms and terms exclusion

### DIFF
--- a/packages/redux-devtools-inspector/src/ActionList.jsx
+++ b/packages/redux-devtools-inspector/src/ActionList.jsx
@@ -85,7 +85,8 @@ export default class ActionList extends Component {
       startActionId,
       onSelect,
       onSearch,
-      searchValue,
+      searchInclude,
+      searchExclude,
       currentActionId,
       hideMainButtons,
       hideActionButtons,
@@ -93,14 +94,14 @@ export default class ActionList extends Component {
       onSweep,
       onJumpToState
     } = this.props;
-    const lowerSearchValue = searchValue && searchValue.toLowerCase();
-    const filteredActionIds = searchValue
-      ? actionIds.filter(
-          id =>
-            actions[id].action.type.toLowerCase().indexOf(lowerSearchValue) !==
-            -1
-        )
-      : actionIds;
+
+    const filteredActionIds = actionIds.filter(id => {
+      const type = actions[id].action.type.toLowerCase();
+      return (
+        searchExclude.every(searchData => !type.includes(searchData)) &&
+        searchInclude.every(searchData => type.includes(searchData))
+      );
+    });
 
     return (
       <div

--- a/packages/redux-devtools-inspector/src/DevtoolsInspector.js
+++ b/packages/redux-devtools-inspector/src/DevtoolsInspector.js
@@ -219,7 +219,8 @@ export default class DevtoolsInspector extends Component {
     const {
       selectedActionId,
       startActionId,
-      searchValue,
+      searchInclude,
+      searchExclude,
       tabName
     } = monitorState;
     const inspectedPathType =
@@ -248,7 +249,8 @@ export default class DevtoolsInspector extends Component {
             actions,
             actionIds,
             isWideLayout,
-            searchValue,
+            searchInclude,
+            searchExclude,
             selectedActionId,
             startActionId,
             skippedActionIds,
@@ -322,8 +324,22 @@ export default class DevtoolsInspector extends Component {
     this.props.dispatch(sweep());
   };
 
-  handleSearch = val => {
-    this.updateMonitorState({ searchValue: val });
+  handleSearch = value => {
+    const segments = value.toLowerCase().trim().split(/\s+/);
+    const searchInclude = [];
+    const searchExclude = [];
+
+    segments.forEach(segment => {
+      if (segment.charAt(0) === '-') {
+        if (segment.length > 1) {
+          searchExclude.push(segment.substr(1));
+        }
+      } else {
+        searchInclude.push(segment);
+      }
+    });
+
+    this.updateMonitorState({ searchInclude, searchExclude });
   };
 
   handleSelectAction = (e, actionId) => {

--- a/packages/redux-devtools-inspector/src/redux.js
+++ b/packages/redux-devtools-inspector/src/redux.js
@@ -5,7 +5,9 @@ export const DEFAULT_STATE = {
   startActionId: null,
   inspectedActionPath: [],
   inspectedStatePath: [],
-  tabName: 'Diff'
+  tabName: 'Diff',
+  searchInclude: [],
+  searchExclude: []
 };
 
 export function updateMonitorState(monitorState) {


### PR DESCRIPTION
This add some new features to the search input : 
- cumulative filtering
- term excluding using the '-' character

## Cumulative filtering

Every spaces in the text field is considered as a "AND" operator.
Typing `request user` will match action types that contain at the same time "request" and "user" :

| | Action type |
| ------------- | ------------- |
| ✅|  **REQUEST**\_ADD\_**USER**  |
| ✅| **REQUEST**\_REMOVE\_**USER**  |
| 🚫| REQUEST_CONTACT |
| 🚫| CONTACT_USER |

## Excluding terms

Every words starting with a "-" is considered as a term to exclude.
Typing `request user -add` will match action types that contain at the same time "request" and "user", but does not contain "add"  :

| | Action type |
| ------------- | ------------- |
| 🚫|  **REQUEST**\_ADD\_**USER**  |
| ✅| **REQUEST**\_REMOVE\_**USER**  |
| ✅| **REQUEST**\_FETCH\_**USER**  |
| ✅| **REQUEST**\_**USER**  |

## Additional notes

It's a breaking change in this cases : 
- If you want to match action that contain spaces.
- If you want to match action that start with `-`.