### PR TITLE
Update react-json-tree peerDependency on react

### DIFF
--- a/packages/react-json-tree/package.json
+++ b/packages/react-json-tree/package.json
@@ -46,7 +46,7 @@
     "@babel/preset-react": "^7.0.0",
     "babel-loader": "^8.0.5",
     "jest": "^24.1.0",
-    "react": "^16.0.0",
+    "react": "^16.3.0",
     "react-dom": "^16.3.0",
     "react-test-renderer": "^16.3.0",
     "rimraf": "^2.5.2",

--- a/packages/react-json-tree/package.json
+++ b/packages/react-json-tree/package.json
@@ -47,16 +47,16 @@
     "babel-loader": "^8.0.5",
     "jest": "^24.1.0",
     "react": "^16.0.0",
-    "react-dom": "^16.0.0",
-    "react-test-renderer": "^16.0.0",
+    "react-dom": "^16.3.0",
+    "react-test-renderer": "^16.3.0",
     "rimraf": "^2.5.2",
     "terser-webpack-plugin": "^1.2.1",
     "webpack": "^4.27.1",
     "webpack-cli": "^3.2.0"
   },
   "peerDependencies": {
-    "react": "^15.0.0 || ^16.0.0",
-    "react-dom": "^15.0.0 || ^16.0.0"
+    "react": "^16.3.0",
+    "react-dom": "^16.3.0"
   },
   "dependencies": {
     "prop-types": "^15.5.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13765,7 +13765,7 @@ react-treebeard@^3.1.0:
     shallowequal "^1.1.0"
     velocity-react "^1.4.1"
 
-react@^16.0.0, react@^16.4.0, react@^16.4.2, react@^16.7.0:
+react@^16.0.0, react@^16.3.0, react@^16.4.0, react@^16.4.2, react@^16.7.0:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react/-/react-16.13.1.tgz#2e818822f1a9743122c063d6410d85c1e3afe48e"
   integrity sha512-YMZQQq32xHLX0bz5Mnibv1/LHb3Sqzngu7xstSM+vrkE5Kzr9xE0yMByK5kMoTK30YVJE61WfbxIFFvfeDKT1w==

--- a/yarn.lock
+++ b/yarn.lock
@@ -13488,7 +13488,7 @@ react-dock@^0.2.4:
     lodash.debounce "^3.1.1"
     prop-types "^15.5.8"
 
-react-dom@^16.0.0, react-dom@^16.4.0, react-dom@^16.4.2, react-dom@^16.7.0:
+react-dom@^16.0.0, react-dom@^16.3.0, react-dom@^16.4.0, react-dom@^16.4.2, react-dom@^16.7.0:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.13.1.tgz#c1bd37331a0486c078ee54c4740720993b2e0e7f"
   integrity sha512-81PIMmVLnCNLO/fFOQxdQkvEq/+Hfpv24XNJfpyZhTRfO0QcmQIF/PgCa1zCOj2w1hrn12MFLyaJ/G0+Mxtfag==
@@ -13718,7 +13718,7 @@ react-style-proptype@^3.2.2:
   dependencies:
     prop-types "^15.5.4"
 
-react-test-renderer@^16.0.0, react-test-renderer@^16.0.0-0, react-test-renderer@^16.4.0:
+react-test-renderer@^16.0.0, react-test-renderer@^16.0.0-0, react-test-renderer@^16.3.0, react-test-renderer@^16.4.0:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-16.13.1.tgz#de25ea358d9012606de51e012d9742e7f0deabc1"
   integrity sha512-Sn2VRyOK2YJJldOqoh8Tn/lWQ+ZiKhyZTPtaO0Q6yNj+QDbmRkVFap6pZPy3YQk8DScRDfyqm/KxKYP9gCMRiQ==


### PR DESCRIPTION
With the merging of https://github.com/reduxjs/redux-devtools/pull/483, we can only support `react@^16.3.0`.