### PR TITLE
[redux-devtools-cli] Forward `port` flag to Electron

### DIFF
--- a/packages/redux-devtools-cli/bin/open.js
+++ b/packages/redux-devtools-cli/bin/open.js
@@ -5,7 +5,11 @@ var spawn = require('cross-spawn');
 function open(app, options) {
   if (app === true || app === 'electron') {
     try {
-      spawn.sync(require('electron'), [path.join(__dirname, '..', 'app')]);
+      var port = options.port ? '--port=' + options.port : '';
+      spawn.sync(require('electron'), [
+        path.join(__dirname, '..', 'app'),
+        port
+      ]);
     } catch (error) {
       /* eslint-disable no-console */
       if (error.message === "Cannot find module 'electron'") {


### PR DESCRIPTION
### Description

When running `redux-devtools` with the `open` flag, the `port` option is ignored in `app/electron.js` as the `spawn` command does not forward the flag from the parent command.

The changes here ensures that the `port` option is forwarded from the `open.js` script so that it can be properly used in the `electron.js` app.