### PR TITLE
use latest symbol-observable in redux-devtools-instrument

### DIFF
--- a/packages/redux-devtools-instrument/package.json
+++ b/packages/redux-devtools-instrument/package.json
@@ -41,7 +41,7 @@
   },
   "dependencies": {
     "lodash": "^4.17.19",
-    "symbol-observable": "^1.2.0"
+    "symbol-observable": "^2.0.3"
   },
   "devDependencies": {
     "@types/lodash": "^4.14.159",

--- a/yarn.lock
+++ b/yarn.lock
@@ -17137,6 +17137,11 @@ symbol-observable@^1.0.4, symbol-observable@^1.2.0:
   resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.2.0.tgz#c22688aed4eab3cdc2dfeacbb561660560a00804"
   integrity sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==
 
+symbol-observable@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-2.0.3.tgz#5b521d3d07a43c351055fa43b8355b62d33fd16a"
+  integrity sha512-sQV7phh2WCYAn81oAkakC5qjq2Ml0g8ozqz03wOGnx9dDlG1de6yrF+0RAzSJD8fPUow3PTSMf2SAbOGxb93BA==
+
 symbol-tree@^3.2.4:
   version "3.2.4"
   resolved "https://registry.yarnpkg.com/symbol-tree/-/symbol-tree-3.2.4.tgz#430637d248ba77e078883951fb9aa0eed7c63fa2"


### PR DESCRIPTION
Latest version is compatible with environments where Symbol may be frozen.