### PR TITLE
Tightens the permissions for which URLs the extension can access

### DIFF
--- a/extension/src/browser/extension/manifest.json
+++ b/extension/src/browser/extension/manifest.json
@@ -65,7 +65,9 @@
     "contextMenus",
     "tabs",
     "storage",
-    "<all_urls>"
+    "file:///*",
+    "http://*/*",
+    "https://*/*"
   ],
   "content_security_policy": "script-src 'self' 'unsafe-eval'; object-src 'self'; style-src * 'unsafe-inline'; img-src 'self' data:;",
   "update_url": "https://clients2.google.com/service/update2/crx",

--- a/extension/src/browser/firefox/manifest.json
+++ b/extension/src/browser/firefox/manifest.json
@@ -59,7 +59,9 @@
     "contextMenus",
     "tabs",
     "storage",
-    "<all_urls>"
+    "file:///*",
+    "http://*/*",
+    "https://*/*"
   ],
   "content_security_policy": "script-src 'self'; object-src 'self'; img-src 'self' data:;"
 }


### PR DESCRIPTION
Fixes #663 - Sets the specific schemes that are supported which specifically excludes FTP