### PR TITLE
Upgrade electron to v11 to support Mac M1 (arm64)

### DIFF
--- a/packages/redux-devtools-cli/package.json
+++ b/packages/redux-devtools-cli/package.json
@@ -48,7 +48,7 @@
     "chalk": "^4.1.0",
     "cors": "^2.8.5",
     "cross-spawn": "^7.0.3",
-    "electron": "^9.2.0",
+    "electron": "^11.1.0",
     "express": "^4.17.1",
     "getport": "^0.1.0",
     "graphql": "^14.7.0",


### PR DESCRIPTION
I have a dependency with `redux-devtools-cli` and got the following error messages on my Mac Silicon M1:

> npm ERR! HTTPError: Response code 404 (Not Found) for https://github.com/electron/electron/releases/download/v9.4.0/electron-v9.4.0-darwin-arm64.zip

```
npm ERR! code 1
npm ERR! path /Users/huan/chatie/wechaty-redux/node_modules/electron
npm ERR! command failed
npm ERR! command sh -c node install.js
npm ERR! HTTPError: Response code 404 (Not Found) for https://github.com/electron/electron/releases/download/v9.4.0/electron-v9.4.0-darwin-arm64.zip
npm ERR!     at EventEmitter.<anonymous> (/Users/huan/chatie/wechaty-redux/node_modules/@electron/get/node_modules/got/source/as-stream.js:35:24)
npm ERR!     at EventEmitter.emit (node:events:376:20)
npm ERR!     at module.exports (/Users/huan/chatie/wechaty-redux/node_modules/@electron/get/node_modules/got/source/get-response.js:22:10)
npm ERR!     at ClientRequest.handleResponse (/Users/huan/chatie/wechaty-redux/node_modules/@electron/get/node_modules/got/source/request-as-event-emitter.js:155:5)
npm ERR!     at Object.onceWrapper (node:events:483:26)
npm ERR!     at ClientRequest.emit (node:events:388:22)
npm ERR!     at ClientRequest.origin.emit (/Users/huan/chatie/wechaty-redux/node_modules/@szmarczak/http-timer/source/index.js:37:11)
npm ERR!     at HTTPParser.parserOnIncomingClient [as onIncoming] (node:_http_client:660:27)
npm ERR!     at HTTPParser.parserOnHeadersComplete (node:_http_common:126:17)
npm ERR!     at TLSSocket.socketOnData (node:_http_client:526:22)
```

So I believe we need to upgrade the electron to the latest version so that we can get the arm64 support.