### PR TITLE
feat(react-json-tree): Add keyPath to getItemString

### DIFF
--- a/packages/react-json-tree/README.md
+++ b/packages/react-json-tree/README.md
@@ -102,14 +102,14 @@ You can pass `getItemString` to customize the way arrays, objects, and iterable 
 By default, it'll be:
 
 ```jsx
-<JSONTree getItemString={(type, data, itemType, itemString)
+<JSONTree getItemString={(type, data, itemType, itemString, keyPath)
   => <span>{itemType} {itemString}</span>}
 ```
 
 But if you pass the following:
 
 ```jsx
-const getItemString = (type, data, itemType, itemString)
+const getItemString = (type, data, itemType, itemString, keyPath)
   => (<span> // {type}</span>);
 ```
 

--- a/packages/react-json-tree/src/JSONNestedNode.tsx
+++ b/packages/react-json-tree/src/JSONNestedNode.tsx
@@ -193,7 +193,8 @@ export default class JSONNestedNode extends React.Component<Props, State> {
       nodeType,
       data,
       itemType,
-      createItemString(data, collectionLimit)
+      createItemString(data, collectionLimit),
+      keyPath
     );
     const stylingArgs = [keyPath, nodeType, expanded, expandable] as const;
 

--- a/packages/react-json-tree/src/types.ts
+++ b/packages/react-json-tree/src/types.ts
@@ -35,7 +35,8 @@ interface JSONNestedNodeCircularPropsPassedThroughJSONTree {
     nodeType: string,
     data: any,
     itemType: React.ReactNode,
-    itemString: string
+    itemString: string,
+    keyPath: (string | number)[]
   ) => React.ReactNode;
   postprocessValue: (value: any) => any;
   isCustomNode: (value: any) => boolean;


### PR DESCRIPTION
Adds `keyPath` to `getItemString` so I can conditionally render different labels depending on the path.

Same as https://github.com/reduxjs/redux-devtools/pull/470, but updated to Typescript. Credit goes to @slavasitnikov, I just ported their changes to the new Typescript.