### PR TITLE
Polyfill `chrome.storage.sync` for Electron

### DIFF
--- a/extension/src/browser/extension/chromeAPIMock.js
+++ b/extension/src/browser/extension/chromeAPIMock.js
@@ -87,6 +87,6 @@ if (window.isElectron) {
   };
 }
 
-if (isFirefox) {
+if (isFirefox || window.isElectron) {
   chrome.storage.sync = chrome.storage.local;
 }


### PR DESCRIPTION
`chrome.storage.sync` is not supported on Electron (https://www.electronjs.org/docs/api/extensions#chromestorage).

Fix #696 