### PR TITLE
fix(*): fix peer dependencies on inpsector monitor

### DIFF
--- a/packages/redux-devtools-inspector-monitor-test-tab/package.json
+++ b/packages/redux-devtools-inspector-monitor-test-tab/package.json
@@ -83,7 +83,7 @@
     "seamless-immutable": "^7.1.4"
   },
   "peerDependencies": {
-    "@redux-devtools/inspector-monitor": "^0.14.0",
+    "@redux-devtools/inspector-monitor": "^1.0.0",
     "@types/react": "^16.3.0 || ^17.0.0",
     "react": "^16.3.0 || ^17.0.0",
     "redux": "^3.4.0 || ^4.0.0"

--- a/packages/redux-devtools-inspector-monitor-trace-tab/package.json
+++ b/packages/redux-devtools-inspector-monitor-trace-tab/package.json
@@ -53,7 +53,7 @@
     "redux": "^4.0.5"
   },
   "peerDependencies": {
-    "@redux-devtools/inspector-monitor": "^0.14.0",
+    "@redux-devtools/inspector-monitor": "^1.0.0",
     "@types/react": "^16.3.0 || ^17.0.0",
     "react": "^16.3.0 || ^17.0.0",
     "redux": "^3.4.0 || ^4.0.0"


### PR DESCRIPTION
Resolves https://github.com/reduxjs/redux-devtools/issues/727.

In the next release I'll bump @redux-devtools/inspector-monitor so this works as expected.