### PR TITLE
fix(trace): restore usage of @babel/code-frames

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,5 +71,8 @@
     "packages/redux-devtools/examples/counter",
     "packages/redux-devtools/examples/todomvc",
     "packages/redux-devtools-slider-monitor/examples/todomvc"
-  ]
+  ],
+  "resolutions": {
+    "@babel/highlight/chalk": "Methuselah96/chalk#head=v2-without-process"
+  }
 }

--- a/packages/redux-devtools-inspector-monitor-trace-tab/src/react-error-overlay/containers/StackFrameCodeBlock.tsx
+++ b/packages/redux-devtools-inspector-monitor-trace-tab/src/react-error-overlay/containers/StackFrameCodeBlock.tsx
@@ -12,7 +12,7 @@ import { absolutifyCaret } from '../utils/dom/absolutifyCaret';
 import { ScriptLine } from '../utils/stack-frame';
 import generateAnsiHTML from '../utils/generateAnsiHTML';
 
-// import { codeFrameColumns } from '@babel/code-frame';
+import { codeFrameColumns } from '@babel/code-frame';
 import { nicinabox as theme } from 'redux-devtools-themes';
 
 interface StackFrameCodeBlockPropsType {
@@ -48,25 +48,24 @@ function StackFrameCodeBlock(props: StackFrameCodeBlockPropsType) {
     }
     sourceCode[line - 1] = text;
   });
-  // const ansiHighlight = codeFrameColumns(
-  //   sourceCode.join('\n'),
-  //   {
-  //     start: {
-  //       line: lineNum,
-  //       column:
-  //         columnNum == null
-  //           ? 0
-  //           : columnNum - (isFinite(whiteSpace) ? whiteSpace : 0),
-  //     },
-  //   },
-  //   {
-  //     forceColor: true,
-  //     linesAbove: contextSize,
-  //     linesBelow: contextSize,
-  //   }
-  // );
-  // const htmlHighlight = generateAnsiHTML(ansiHighlight);
-  const htmlHighlight = generateAnsiHTML(sourceCode.join('\n'));
+  const ansiHighlight = codeFrameColumns(
+    sourceCode.join('\n'),
+    {
+      start: {
+        line: lineNum,
+        column:
+          columnNum == null
+            ? 0
+            : columnNum - (isFinite(whiteSpace) ? whiteSpace : 0),
+      },
+    },
+    {
+      forceColor: true,
+      linesAbove: contextSize,
+      linesBelow: contextSize,
+    }
+  );
+  const htmlHighlight = generateAnsiHTML(ansiHighlight);
   const code = document.createElement('code');
   code.innerHTML = htmlHighlight;
   absolutifyCaret(code);

--- a/yarn.lock
+++ b/yarn.lock
@@ -11008,6 +11008,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"chalk@Methuselah96/chalk#head=v2-without-process":
+  version: 2.4.2
+  resolution: "chalk@https://github.com/Methuselah96/chalk.git#commit=3dd077ca367b80efec4b522cc300d68b4974499e"
+  dependencies:
+    ansi-styles: ^3.2.1
+    escape-string-regexp: ^1.0.5
+    supports-color: ^5.3.0
+  checksum: dbe195f24bc04b95494b966dd357d9389c57092b548138f9d49b8e7d4a3c9d6f81e181fb52afbebf12ab8abec7e2ae04cd409c83cdcc275bc1f72bb82f4c954c
+  languageName: node
+  linkType: hard
+
 "chalk@npm:2.4.2, chalk@npm:^2.0.0, chalk@npm:^2.0.1, chalk@npm:^2.3.0, chalk@npm:^2.4.1, chalk@npm:^2.4.2":
   version: 2.4.2
   resolution: "chalk@npm:2.4.2"


### PR DESCRIPTION
The resolution can be removed once chalk is upgraded in @babel/highlight (after Babel 8 is released and they can drop support for older versions of Node).