### PR TITLE
fix(extension): remove socket from panel store

### DIFF
--- a/extension/src/app/reducers/panel/index.ts
+++ b/extension/src/app/reducers/panel/index.ts
@@ -6,7 +6,6 @@ import reports from '@redux-devtools/app/lib/reducers/reports';
 import section from '@redux-devtools/app/lib/reducers/section';
 import theme from '@redux-devtools/app/lib/reducers/theme';
 import connection from '@redux-devtools/app/lib/reducers/connection';
-import socket from '@redux-devtools/app/lib/reducers/socket';
 import { StoreState } from '@redux-devtools/app/lib/reducers';
 import { StoreActionWithTogglePersist } from '../../stores/windowStore';
 
@@ -19,7 +18,6 @@ const rootReducer: Reducer<StoreState, StoreActionWithTogglePersist> =
     section,
     theme,
     connection,
-    socket,
   });
 
 export default rootReducer;


### PR DESCRIPTION
See comments on https://github.com/zalmoxisus/redux-devtools-extension/commit/15161035f0c97d1a5ad9621bc599a845a2510a26 for why `socket` exists on `window`, but not `panel`.