### PR TITLE
fix(extension): remove special case for JUMP_TO_STATE

### DIFF
--- a/extension/src/app/containers/Actions.tsx
+++ b/extension/src/app/containers/Actions.tsx
@@ -2,10 +2,7 @@ import React, { Component } from 'react';
 import { connect, ResolveThunks } from 'react-redux';
 import { Button, Container, Divider, Toolbar } from 'devui';
 import SliderMonitor from '@redux-devtools/app/lib/containers/monitors/Slider';
-import {
-  liftedDispatch as liftedDispatchAction,
-  getReport,
-} from '@redux-devtools/app/lib/actions';
+import { liftedDispatch, getReport } from '@redux-devtools/app/lib/actions';
 import { getActiveInstance } from '@redux-devtools/app/lib/reducers/instances';
 import DevTools from '@redux-devtools/app/lib/containers/DevTools';
 import Dispatcher from '@redux-devtools/app/lib/containers/monitors/Dispatcher';
@@ -161,7 +158,7 @@ const mapStateToProps = (state: StoreState) => {
 };
 
 const actionCreators = {
-  liftedDispatch: liftedDispatchAction,
+  liftedDispatch,
   getReport,
 };
 

--- a/extension/src/browser/extension/inject/pageScript.ts
+++ b/extension/src/browser/extension/inject/pageScript.ts
@@ -426,13 +426,6 @@ function __REDUX_DEVTOOLS_EXTENSION__<S, A extends Action<unknown>>(
       if (!features.lock && action.type === 'LOCK_CHANGES') return;
       if (!features.pause && action.type === 'PAUSE_RECORDING') return;
     }
-    if (action.type === 'JUMP_TO_STATE') {
-      const liftedState = store.liftedStore.getState();
-      const index = liftedState.stagedActionIds.indexOf(action.actionId);
-      if (index === -1) return;
-      store.liftedStore.dispatch({ type: action.type, index });
-      return;
-    }
     store.liftedStore.dispatch(action as any);
   }
 

--- a/packages/redux-devtools-app/src/containers/Actions.tsx
+++ b/packages/redux-devtools-app/src/containers/Actions.tsx
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import { connect, ResolveThunks } from 'react-redux';
 import { Container } from 'devui';
 import SliderMonitor from './monitors/Slider';
-import { liftedDispatch as liftedDispatchAction, getReport } from '../actions';
+import { liftedDispatch, getReport } from '../actions';
 import { getActiveInstance } from '../reducers/instances';
 import DevTools from '../containers/DevTools';
 import Dispatcher from './monitors/Dispatcher';
@@ -69,7 +69,7 @@ const mapStateToProps = (state: StoreState) => {
 };
 
 const actionCreators = {
-  liftedDispatch: liftedDispatchAction,
+  liftedDispatch,
   getReport,
 };
 


### PR DESCRIPTION
This piece of code was first introduced [here](https://github.com/zalmoxisus/redux-devtools-extension/commit/1277947278dd2b14ede5a9083f361d486ebff362) with [this](https://github.com/zalmoxisus/remotedev-slider/commit/4c84bbbe5487ff23519d039380d0cdd3a0aeaea5) corresponding change in the slider monitor.

These were introduced in order to fix jumping to a certain state when there are filtered actions in the extension The problem is that we then switched back to using the normal slider monitor which doesn't provide the `actionId` and so the slider broke in the extension. I'm not convinced that the previous solution is preferred because it requires monitors to update their code to accommodate the extension.

I'm deferring to the proper fix for this to https://github.com/reduxjs/redux-devtools/issues/830.