### PR TITLE
fix(rtk-query-monitor): capitalize tabs #995

### DIFF
--- a/packages/redux-devtools-rtk-query-monitor/src/containers/QueryPreview.tsx
+++ b/packages/redux-devtools-rtk-query-monitor/src/containers/QueryPreview.tsx
@@ -94,7 +94,7 @@ const tabs: ReadonlyArray<
   TabOption<QueryPreviewTabs, QueryPreviewTabProps, RtkResourceInfo['type']>
 > = [
   {
-    label: 'query',
+    label: 'Query',
     value: QueryPreviewTabs.queryinfo,
     component: MappedQueryPreviewInfo,
     visible: {
@@ -104,7 +104,7 @@ const tabs: ReadonlyArray<
     },
   },
   {
-    label: 'actions',
+    label: 'Actions',
     value: QueryPreviewTabs.actions,
     component: MappedQueryPreviewActions,
     visible: {
@@ -114,7 +114,7 @@ const tabs: ReadonlyArray<
     },
   },
   {
-    label: 'tags',
+    label: 'Tags',
     value: QueryPreviewTabs.queryTags,
     component: MappedQueryPreviewTags,
     visible: {
@@ -124,7 +124,7 @@ const tabs: ReadonlyArray<
     },
   },
   {
-    label: 'subs',
+    label: 'Subs',
     value: QueryPreviewTabs.querySubscriptions,
     component: MappedQuerySubscriptipns,
     visible: {
@@ -134,7 +134,7 @@ const tabs: ReadonlyArray<
     },
   },
   {
-    label: 'api',
+    label: 'Api',
     value: QueryPreviewTabs.apiConfig,
     component: MappedApiPreview,
   },


### PR DESCRIPTION
Partially fixes https://github.com/reduxjs/redux-devtools/issues/995


---

@Methuselah96  Is there a way make VScode work with plug'n'Play:
It is a squiggly line fest and not even the good ol' `restart TS server` seems to work in this case.