### PR TITLE
Remove React from page bundle

### DIFF
--- a/extension/src/app/stores/enhancerStore.ts
+++ b/extension/src/app/stores/enhancerStore.ts
@@ -1,6 +1,6 @@
 import { Action, compose, Reducer, StoreEnhancerStoreCreator } from 'redux';
 import { instrument } from '@redux-devtools/instrument';
-import { persistState } from '@redux-devtools/core';
+import persistState from './persistState';
 import { ConfigWithExpandedMaxAge } from '../../browser/extension/inject/pageScript';
 
 export function getUrlParam(key: string) {

--- a/extension/src/app/stores/persistState.ts
+++ b/extension/src/app/stores/persistState.ts
@@ -1,4 +1,5 @@
-import _ from 'lodash';
+import mapValues from 'lodash/mapValues';
+import identity from 'lodash/identity';
 import { Action, PreloadedState, Reducer, StoreEnhancer } from 'redux';
 import { LiftedState } from '@redux-devtools/instrument';
 
@@ -8,8 +9,8 @@ export default function persistState<
   MonitorState
 >(
   sessionId?: string | null,
-  deserializeState: (state: S) => S = _.identity,
-  deserializeAction: (action: A) => A = _.identity
+  deserializeState: (state: S) => S = identity,
+  deserializeAction: (action: A) => A = identity
 ): StoreEnhancer {
   if (!sessionId) {
     return (next) =>
@@ -22,7 +23,7 @@ export default function persistState<
   ): LiftedState<S, A, MonitorState> {
     return {
       ...state,
-      actionsById: _.mapValues(state.actionsById, (liftedAction) => ({
+      actionsById: mapValues(state.actionsById, (liftedAction) => ({
         ...liftedAction,
         action: deserializeAction(liftedAction.action),
       })),

--- a/extension/src/app/stores/persistState.ts
+++ b/extension/src/app/stores/persistState.ts
@@ -1,0 +1,82 @@
+import _ from 'lodash';
+import { Action, PreloadedState, Reducer, StoreEnhancer } from 'redux';
+import { LiftedState } from '@redux-devtools/instrument';
+
+export default function persistState<
+  S,
+  A extends Action<unknown>,
+  MonitorState
+>(
+  sessionId?: string | null,
+  deserializeState: (state: S) => S = _.identity,
+  deserializeAction: (action: A) => A = _.identity
+): StoreEnhancer {
+  if (!sessionId) {
+    return (next) =>
+      (...args) =>
+        next(...args);
+  }
+
+  function deserialize(
+    state: LiftedState<S, A, MonitorState>
+  ): LiftedState<S, A, MonitorState> {
+    return {
+      ...state,
+      actionsById: _.mapValues(state.actionsById, (liftedAction) => ({
+        ...liftedAction,
+        action: deserializeAction(liftedAction.action),
+      })),
+      committedState: deserializeState(state.committedState),
+      computedStates: state.computedStates.map((computedState) => ({
+        ...computedState,
+        state: deserializeState(computedState.state),
+      })),
+    };
+  }
+
+  return (next) =>
+    <S2, A2 extends Action<unknown>>(
+      reducer: Reducer<S2, A2>,
+      initialState?: PreloadedState<S2>
+    ) => {
+      const key = `redux-dev-session-${sessionId}`;
+
+      let finalInitialState;
+      try {
+        const json = localStorage.getItem(key);
+        if (json) {
+          finalInitialState =
+            deserialize(JSON.parse(json) as LiftedState<S, A, MonitorState>) ||
+            initialState;
+          next(reducer, initialState);
+        }
+      } catch (e) {
+        console.warn('Could not read debug session from localStorage:', e); // eslint-disable-line no-console
+        try {
+          localStorage.removeItem(key);
+        } finally {
+          finalInitialState = undefined;
+        }
+      }
+
+      const store = next(
+        reducer,
+        finalInitialState as PreloadedState<S2> | undefined
+      );
+
+      return {
+        ...store,
+        dispatch<T extends A2>(action: T) {
+          store.dispatch(action);
+
+          try {
+            localStorage.setItem(key, JSON.stringify(store.getState()));
+          } catch (e) {
+            console.warn('Could not write debug session to localStorage:', e); // eslint-disable-line no-console
+          }
+
+          return action;
+        },
+      };
+    };
+}


### PR DESCRIPTION
Fixes https://github.com/reduxjs/redux-devtools/issues/1030. The issue is that we're importing `persistState` from `@redux-devtools/core` in the page bundle, but that ends up importing all of `@redux-devtools/core` which imports `react`.

This draft PR is just to get unstuck until I figure out how this should be done without copy-pasting `persist-state` from `@redux-devtools/core`. Looks like multiple entry points using the exports field in `package.json` is still being worked on for TypeScript (or at least the issue for it is still open) and I'm not really sure if the methods in `@redux-devtools/core` can be considered "side-effect free." They definitely have side-effects, but the side-effects aren't meaningful to anybody else and should be fine to be tree-shaken.

tl;dr need to investigate more but can publish this for now