### PR TITLE
.npmignore: rn-host-detect.ts

### DIFF
--- a/packages/redux-devtools-remote/.npmignore
+++ b/packages/redux-devtools-remote/.npmignore
@@ -1,0 +1,1 @@
+src/rn-host-detect.ts


### PR DESCRIPTION
The presence of this file leads to a build error `[...]\node_modules\@redux-devtools\remote\src\rn-host-detect.ts is missing from the TypeScript compilation. Please make sure it is in your tsconfig fia the 'files or 'include' property.`

This can be solved by including a path to this specific file in my app's tsconfig.json file, but it's an inelegant solution - this would be the only file in node_modules that has to be included like that.
It doesn't actually serve any purpose in the deployed package, and the typings file would still be present.