### PR TITLE
Update branch name on package file

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2015-present Dan Abramov
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/redux-devtools/package.json
+++ b/packages/redux-devtools/package.json
@@ -10,7 +10,7 @@
     "time travel",
     "live edit"
   ],
-  "homepage": "https://github.com/reduxjs/redux-devtools/tree/master/packages/redux-devtools",
+  "homepage": "https://github.com/reduxjs/redux-devtools/tree/main/packages/redux-devtools",
   "bugs": {
     "url": "https://github.com/reduxjs/redux-devtools/issues"
   },


### PR DESCRIPTION
* License file is extremely useful for crawlers looking for 3rd party software libs. I've used the exact same one from other repos under reduxjs.
* `package.json` file was still pointing at `master`, instead of `main` which is the current main branch.
