### PR TITLE
fix(compose): generic types for devtools/extension

### DIFF
--- a/extension/src/browser/extension/inject/pageScript.ts
+++ b/extension/src/browser/extension/inject/pageScript.ts
@@ -600,8 +600,8 @@ const extensionCompose =
   };
 
 interface ReduxDevtoolsExtensionCompose {
-  (config: Config): (...funcs: StoreEnhancer[]) => StoreEnhancer;
-  (...funcs: StoreEnhancer[]): StoreEnhancer;
+  (config: Config): <StoreExt>(...funcs: Array<StoreEnhancer<StoreExt>>) => StoreEnhancer<StoreExt>;
+  <StoreExt>(...funcs: Array<StoreEnhancer<StoreExt>>): StoreEnhancer<StoreExt>;
 }
 
 declare global {
@@ -610,20 +610,20 @@ declare global {
   }
 }
 
-function reduxDevtoolsExtensionCompose(
+function reduxDevtoolsExtensionCompose<StoreExt>(
   config: Config
-): (...funcs: StoreEnhancer[]) => StoreEnhancer;
-function reduxDevtoolsExtensionCompose(
-  ...funcs: StoreEnhancer[]
-): StoreEnhancer;
-function reduxDevtoolsExtensionCompose(...funcs: [Config] | StoreEnhancer[]) {
+): (...funcs: Array<StoreEnhancer<StoreExt>>) => StoreEnhancer<StoreExt>;
+function reduxDevtoolsExtensionCompose<StoreExt>(
+  ...funcs: Array<StoreEnhancer<StoreExt>>
+): StoreEnhancer<StoreExt>;
+function reduxDevtoolsExtensionCompose<StoreExt>(...funcs: [Config] | Array<StoreEnhancer<StoreExt>>) {
   if (funcs.length === 0) {
     return __REDUX_DEVTOOLS_EXTENSION__();
   }
   if (funcs.length === 1 && typeof funcs[0] === 'object') {
     return extensionCompose(funcs[0]);
   }
-  return extensionCompose({})(...(funcs as StoreEnhancer[]));
+  return extensionCompose({})(...(funcs as Array<StoreEnhancer<StoreExt>>));
 }
 
 window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ = reduxDevtoolsExtensionCompose;

--- a/extension/src/browser/extension/inject/pageScript.ts
+++ b/extension/src/browser/extension/inject/pageScript.ts
@@ -600,7 +600,9 @@ const extensionCompose =
   };
 
 interface ReduxDevtoolsExtensionCompose {
-  (config: Config): <StoreExt>(...funcs: Array<StoreEnhancer<StoreExt>>) => StoreEnhancer<StoreExt>;
+  (config: Config): <StoreExt>(
+    ...funcs: Array<StoreEnhancer<StoreExt>>
+  ) => StoreEnhancer<StoreExt>;
   <StoreExt>(...funcs: Array<StoreEnhancer<StoreExt>>): StoreEnhancer<StoreExt>;
 }
 
@@ -616,7 +618,9 @@ function reduxDevtoolsExtensionCompose<StoreExt>(
 function reduxDevtoolsExtensionCompose<StoreExt>(
   ...funcs: Array<StoreEnhancer<StoreExt>>
 ): StoreEnhancer<StoreExt>;
-function reduxDevtoolsExtensionCompose<StoreExt>(...funcs: [Config] | Array<StoreEnhancer<StoreExt>>) {
+function reduxDevtoolsExtensionCompose<StoreExt>(
+  ...funcs: [Config] | Array<StoreEnhancer<StoreExt>>
+) {
   if (funcs.length === 0) {
     return __REDUX_DEVTOOLS_EXTENSION__();
   }

--- a/packages/redux-devtools-extension/src/index.ts
+++ b/packages/redux-devtools-extension/src/index.ts
@@ -195,8 +195,8 @@ interface ReduxDevtoolsExtension {
 }
 
 export interface ReduxDevtoolsExtensionCompose {
-  (config: Config): (...funcs: StoreEnhancer[]) => StoreEnhancer;
-  (...funcs: StoreEnhancer[]): StoreEnhancer;
+  (config: Config): <StoreExt>(...funcs: Array<StoreEnhancer<StoreExt>>) => StoreEnhancer<StoreExt>;
+  <StoreExt>(...funcs: Array<StoreEnhancer<StoreExt>>): StoreEnhancer<StoreExt>;
 }
 
 declare global {
@@ -206,14 +206,14 @@ declare global {
   }
 }
 
-function extensionComposeStub(
+function extensionComposeStub<StoreExt>(
   config: Config
-): (...funcs: StoreEnhancer[]) => StoreEnhancer;
-function extensionComposeStub(...funcs: StoreEnhancer[]): StoreEnhancer;
-function extensionComposeStub(...funcs: [Config] | StoreEnhancer[]) {
+): (...funcs: Array<StoreEnhancer<StoreExt>>) => StoreEnhancer<StoreExt>;
+function extensionComposeStub<StoreExt>(...funcs: Array<StoreEnhancer<StoreExt>>): StoreEnhancer<StoreExt>;
+function extensionComposeStub<StoreExt>(...funcs: [Config] | Array<StoreEnhancer<StoreExt>>) {
   if (funcs.length === 0) return undefined;
   if (typeof funcs[0] === 'object') return compose;
-  return compose(...(funcs as StoreEnhancer[]));
+  return compose(...(funcs as Array<StoreEnhancer<StoreExt>>));
 }
 
 export const composeWithDevTools: ReduxDevtoolsExtensionCompose =

--- a/packages/redux-devtools-extension/src/index.ts
+++ b/packages/redux-devtools-extension/src/index.ts
@@ -195,7 +195,9 @@ interface ReduxDevtoolsExtension {
 }
 
 export interface ReduxDevtoolsExtensionCompose {
-  (config: Config): <StoreExt>(...funcs: Array<StoreEnhancer<StoreExt>>) => StoreEnhancer<StoreExt>;
+  (config: Config): <StoreExt>(
+    ...funcs: Array<StoreEnhancer<StoreExt>>
+  ) => StoreEnhancer<StoreExt>;
   <StoreExt>(...funcs: Array<StoreEnhancer<StoreExt>>): StoreEnhancer<StoreExt>;
 }
 
@@ -209,8 +211,12 @@ declare global {
 function extensionComposeStub<StoreExt>(
   config: Config
 ): (...funcs: Array<StoreEnhancer<StoreExt>>) => StoreEnhancer<StoreExt>;
-function extensionComposeStub<StoreExt>(...funcs: Array<StoreEnhancer<StoreExt>>): StoreEnhancer<StoreExt>;
-function extensionComposeStub<StoreExt>(...funcs: [Config] | Array<StoreEnhancer<StoreExt>>) {
+function extensionComposeStub<StoreExt>(
+  ...funcs: Array<StoreEnhancer<StoreExt>>
+): StoreEnhancer<StoreExt>;
+function extensionComposeStub<StoreExt>(
+  ...funcs: [Config] | Array<StoreEnhancer<StoreExt>>
+) {
   if (funcs.length === 0) return undefined;
   if (typeof funcs[0] === 'object') return compose;
   return compose(...(funcs as Array<StoreEnhancer<StoreExt>>));


### PR DESCRIPTION
I wrote generic types for devtools/extension compose function because when passing async thunk-functions in store.dispatch typescript gives an error about type incompatibility.

`Argument of type '(dispatch: asyncThunkDispatch) => Promise<void>' is not assignable to parameter of type 'appActionTypes | etc'. ts(2345)`