### PR TITLE
chore: replace `git.io` from debug message

### DIFF
--- a/extension/src/app/api/index.ts
+++ b/extension/src/app/api/index.ts
@@ -56,7 +56,7 @@ function stringify(obj: unknown, serialize?: Serialize | undefined) {
     // 16 MB
     /* eslint-disable no-console */
     console.warn(
-      'Application state or actions payloads are too large making Redux DevTools serialization slow and consuming a lot of memory. See https://git.io/fpcP5 on how to configure it.'
+      'Application state or actions payloads are too large making Redux DevTools serialization slow and consuming a lot of memory. See https://github.com/reduxjs/redux-devtools-extension/blob/master/docs/Troubleshooting.md#excessive-use-of-memory-and-cpu on how to configure it.'
     );
     /* eslint-enable no-console */
     stringifyWarned = true;


### PR DESCRIPTION
All links on git.io will stop redirecting after April 29, 2022: https://github.blog/changelog/2022-04-25-git-io-deprecation/

Fixes #1146 

---

Alternative solution: should redux provide its own redirection under the domain `https://redux.js.org/`?

Also, is it required to release a new version after the change? If so, should I create a changeset for it?