### PR TITLE
Provide explicit constraints for TypeScript 4.8

### DIFF
--- a/packages/redux-devtools-extension/src/utils/assign.ts
+++ b/packages/redux-devtools-extension/src/utils/assign.ts
@@ -8,7 +8,7 @@ const objectKeys =
     return keys;
   };
 
-export default function assign<T, K extends keyof T>(
+export default function assign<T extends object, K extends keyof T>(
   obj: T,
   newKey: K,
   newValue: T[K]

--- a/packages/redux-devtools-ui/src/Tabs/Tabs.stories.tsx
+++ b/packages/redux-devtools-ui/src/Tabs/Tabs.stories.tsx
@@ -18,7 +18,7 @@ export default {
   component: Tabs,
 };
 
-const Template: Story<TabsProps<unknown>> = (args) => (
+const Template: Story<TabsProps<object>> = (args) => (
   <Container>
     <Tabs {...args} />
   </Container>

--- a/packages/redux-devtools-ui/src/Tabs/Tabs.tsx
+++ b/packages/redux-devtools-ui/src/Tabs/Tabs.tsx
@@ -14,9 +14,7 @@ export interface TabsProps<P> {
   position: Position;
 }
 
-export default class Tabs<P extends JSX.IntrinsicAttributes> extends Component<
-  TabsProps<P>
-> {
+export default class Tabs<P extends object> extends Component<TabsProps<P>> {
   SelectedComponent?: React.ComponentType<P>;
   selector?: () => P;
 

--- a/packages/redux-devtools-ui/src/Tabs/Tabs.tsx
+++ b/packages/redux-devtools-ui/src/Tabs/Tabs.tsx
@@ -14,7 +14,7 @@ export interface TabsProps<P> {
   position: Position;
 }
 
-export default class Tabs<P> extends Component<TabsProps<P>> {
+export default class Tabs<P extends JSX.IntrinsicAttributes> extends Component<TabsProps<P>> {
   SelectedComponent?: React.ComponentType<P>;
   selector?: () => P;
 

--- a/packages/redux-devtools-ui/src/Tabs/Tabs.tsx
+++ b/packages/redux-devtools-ui/src/Tabs/Tabs.tsx
@@ -14,7 +14,9 @@ export interface TabsProps<P> {
   position: Position;
 }
 
-export default class Tabs<P extends JSX.IntrinsicAttributes> extends Component<TabsProps<P>> {
+export default class Tabs<P extends JSX.IntrinsicAttributes> extends Component<
+  TabsProps<P>
+> {
   SelectedComponent?: React.ComponentType<P>;
   selector?: () => P;
 


### PR DESCRIPTION
Hi there! 👋

TypeScript recently added some stricter checking around unconstrained generics being incompatible with emptyish object types. The changes are only in nightly versions of TypeScript right now, but we've been exploring how open-source projects have been impacted. These are the changes necessary for redux-devtools-extension to build cleanly.