### PR TITLE
Propagate store enhancer generic type when using composeWithDevTools

### DIFF
--- a/.changeset/silent-rats-tickle.md
+++ b/.changeset/silent-rats-tickle.md
@@ -1,0 +1,5 @@
+---
+"@redux-devtools/extension": patch
+---
+
+Propagate store enhancer generic type when using composeWithDevTools

--- a/.changeset/silent-rats-tickle.md
+++ b/.changeset/silent-rats-tickle.md
@@ -1,5 +1,5 @@
 ---
-"@redux-devtools/extension": patch
+'@redux-devtools/extension': patch
 ---
 
 Propagate store enhancer generic type when using composeWithDevTools


### PR DESCRIPTION
Alternative fix to https://github.com/reduxjs/redux-devtools/pull/1135.