### PR TITLE
Pass action to trace (#1100)

### DIFF
--- a/extension/src/pageScript/index.ts
+++ b/extension/src/pageScript/index.ts
@@ -112,7 +112,9 @@ export interface ConfigWithExpandedMaxAge {
         currentLiftedAction: LiftedAction<S, A, unknown>,
         previousLiftedState: LiftedState<S, A, unknown> | undefined
       ) => number);
-  readonly trace?: boolean | (() => string | undefined);
+  readonly trace?:
+    | boolean
+    | (<A extends Action<unknown>>(action: A) => string | undefined);
   readonly traceLimit?: number;
   readonly shouldCatchErrors?: boolean;
   readonly shouldHotReload?: boolean;

--- a/packages/redux-devtools-utils/src/index.ts
+++ b/packages/redux-devtools-utils/src/index.ts
@@ -216,14 +216,15 @@ export function getSeralizeParameter(
   return value;
 }
 
-export function getStackTrace(
+export function getStackTrace<A extends Action<unknown>>(
   // eslint-disable-next-line @typescript-eslint/ban-types
-  config: { trace?: () => {}; traceLimit: number },
+  config: { trace?: (action?: A) => {}; traceLimit: number },
   // eslint-disable-next-line @typescript-eslint/ban-types
-  toExcludeFromTrace?: Function | undefined
+  toExcludeFromTrace?: Function | undefined,
+  action?: A
 ) {
   if (!config.trace) return undefined;
-  if (typeof config.trace === 'function') return config.trace();
+  if (typeof config.trace === 'function') return config.trace(action);
 
   let stack;
   let extraFrames = 0;


### PR DESCRIPTION
Resolves #1100 

From the docs, the `trace` function that returns a stack trace is supposed to be passed the action, so this fixes that. 

This should help some of the new JS state managers support all devtools features. 

See: 

https://github.com/pmndrs/valtio/issues/331
https://github.com/pmndrs/zustand/issues/716