### PR TITLE
Increase min-width for popup

### DIFF
--- a/.changeset/short-lamps-cross.md
+++ b/.changeset/short-lamps-cross.md
@@ -1,0 +1,5 @@
+---
+'remotedev-redux-devtools-extension': patch
+---
+
+Increase min-width of popup

--- a/extension/src/window/index.tsx
+++ b/extension/src/window/index.tsx
@@ -35,4 +35,5 @@ chrome.runtime.getBackgroundPage((window) => {
   );
 });
 
+if (position === '#popup') document.body.style.minWidth = '760px';
 if (position !== '#popup') document.body.style.minHeight = '100%';


### PR DESCRIPTION
Fixes #1465.

As discussed in the issue, this seems to be a change from Chrome 114 to Chrome 116. Without pouring all my free time into understanding what's going on here, we're going to set the `min-width` of the popup.