### PR TITLE
Adds argument to prevent Redux DevTool CLI disconnecting when debugging

### DIFF
--- a/packages/redux-devtools-cli/CHANGELOG.md
+++ b/packages/redux-devtools-cli/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change Log
 
+## 4.1.0
+
+### Minor changes
+
+- adds CLI argument to change ping timeout `--pingTimeout=20000` to make debugging easier
+- fixes `--maxRequestBody` argument
+
 ## 4.0.0
 
 ### Major Changes

--- a/packages/redux-devtools-cli/README.md
+++ b/packages/redux-devtools-cli/README.md
@@ -99,6 +99,7 @@ To use WSS, set `protocol` argument to `https` and provide `key`, `cert` and `pa
 | `--logLevel`     | the socket server log level - 0=none, 1=error, 2=warn, 3=info                                                                                                                                                                                                 | 3             |
 | `--wsEngine`     | the socket server web socket engine - ws or uws (sc-uws)                                                                                                                                                                                                      | ws            |
 | `--open`         | open Redux DevTools as a standalone application or as web app. See [Open Redux DevTools](#open-redux-devtools) for details.                                                                                                                                   | false         |
+| `--pingTimeout`  | if debugged app is not responding for 20 seconds (because it paused on breakpoint) the Redux DevTools will disconnect. This can extend it to e.g. 8 hours `28000000`ms                                                                                        | 20000         |
 
 ### Inject to React Native local server
 

--- a/packages/redux-devtools-cli/package.json
+++ b/packages/redux-devtools-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@redux-devtools/cli",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "description": "CLI for remote debugging with Redux DevTools.",
   "homepage": "https://github.com/reduxjs/redux-devtools/tree/master/packages/redux-devtools-cli",
   "bugs": {

--- a/packages/redux-devtools-cli/src/options.ts
+++ b/packages/redux-devtools-cli/src/options.ts
@@ -24,6 +24,7 @@ export interface Options {
   dbOptions: DbOptions;
   maxRequestBody: string;
   logHTTPRequests?: boolean;
+  pingTimeout: number;
   logLevel: 0 | 1 | 3 | 2;
   wsEngine: string;
 }
@@ -59,9 +60,10 @@ export default function getOptions(argv: { [arg: string]: any }): Options {
             undefined,
         },
     dbOptions: dbOptions,
-    maxRequestBody: argv.passphrase || '16mb',
+    maxRequestBody: argv.maxRequestBody || '16mb',
     logHTTPRequests: argv.logHTTPRequests,
     logLevel: argv.logLevel || 3,
+    pingTimeout: argv.pingTimeout || 20000,
     wsEngine:
       argv.wsEngine || process.env.npm_package_remotedev_wsengine || 'ws',
   };


### PR DESCRIPTION
Adds new CLI argument to change pingTimeout value. This solves few issues for me if I set crazy high number.

1) UXP in Photoshop has UWP implementation of WebSockets and its client when asked to send empty message it is never sent but everything else is. Thefore it gets disconnected. https://github.com/reduxjs/redux-devtools/issues/1614

2) I think for some older middleware using protocol V1 sending different ping content this could help as well https://github.com/zalmoxisus/remote-redux-devtools/issues/158

3) When you debug client app and you stop on breakpoint for 20s which default value of socket cluster... it will disconnect debugger as well because you stopped client app so it can't send a ping. So value can be increased to prevent that.

Also `maxRequestBody` was wrong.

Please let me know if I should change something or feel free to change it yourself. I was thinking about seconds instead of `ms` but not sure what is better.