### PR TITLE
Add support for JetBrains server in openFile

### DIFF
--- a/packages/redux-devtools-inspector-monitor-trace-tab/src/openFile.ts
+++ b/packages/redux-devtools-inspector-monitor-trace-tab/src/openFile.ts
@@ -84,6 +84,9 @@ function openInEditor(editor: string, path: string, stackFrame: StackFrame) {
     case 'idea':
       url = `${editor}://open?file=${projectPath}${filePath}&line=${line}&column=${column}`;
       break;
+    case 'jetbrains_server':
+      url = `http://localhost:63342/api/file/?file=${filePath}&line=${line}`;
+      break;
     default:
       // sublime, emacs, macvim, textmate + custom like https://github.com/eclemens/atom-url-handler
       url = `${editor}://open/?url=file://${projectPath}${filePath}&line=${line}&column=${column}`;


### PR DESCRIPTION
The code has been updated to include an additional case for 'JetBrains_server' in the switch statement. This allows the openFile function to generate a URL for opening files on a JetBrains server, respecting the particular file path and line.

The changes:

```typescript
case 'jetbrains_server':
  url = `http://localhost:63342/api/file/?file=${filePath}&line=${line}`;
  break;

in packages/redux-devtools-inspector-monitor-trace-tab/src/openFile.ts