### PR TITLE
Revert "Add polyfill for Symbol.asyncIterator (#1642)"

### DIFF
--- a/.changeset/silly-windows-flow.md
+++ b/.changeset/silly-windows-flow.md
@@ -1,0 +1,5 @@
+---
+'@redux-devtools/remote': patch
+---
+
+Revert "Add polyfill for Symbol.asyncIterator (#1642)"

--- a/packages/redux-devtools-remote/src/devTools.ts
+++ b/packages/redux-devtools-remote/src/devTools.ts
@@ -1,6 +1,3 @@
-(Symbol as any).asyncIterator =
-  Symbol.asyncIterator || Symbol.for('Symbol.asyncIterator');
-
 import { stringify, parse } from 'jsan';
 import socketClusterClient, { AGClientSocket } from 'socketcluster-client';
 import configureStore from './configureStore';


### PR DESCRIPTION
Apparently [breaks Electron](https://github.com/reduxjs/redux-devtools/issues/1382#issuecomment-2028888089) and [doesn't fix Hermes](https://github.com/reduxjs/redux-devtools/issues/1382#issuecomment-2027810913) anyway.