### PR TITLE
Enable lock button for non-Redux connections.

### DIFF
--- a/.changeset/neat-ducks-do.md
+++ b/.changeset/neat-ducks-do.md
@@ -1,5 +1,5 @@
 ---
-"@redux-devtools/app": minor
+'@redux-devtools/app': minor
 ---
 
 Enable lock button for non-Redux connections

--- a/.changeset/neat-ducks-do.md
+++ b/.changeset/neat-ducks-do.md
@@ -1,0 +1,5 @@
+---
+"@redux-devtools/app": minor
+---
+
+Enable lock button for non-Redux connections

--- a/packages/redux-devtools-app/src/components/TopButtons.tsx
+++ b/packages/redux-devtools-app/src/components/TopButtons.tsx
@@ -52,9 +52,7 @@ export default class TopButtons extends Component<Props> {
       <Toolbar borderPosition="bottom">
         {features.pause && <RecordButton paused={isPaused} />}
         {features.persist && <PersistButton />}
-        {features.lock && (
-          <LockButton locked={isLocked} disabled={options.lib !== 'redux'} />
-        )}
+        {features.lock && <LockButton locked={isLocked} />}
         <Divider />
         <Button
           title="Reset to the state you created the store with"

--- a/packages/redux-devtools-app/src/components/buttons/LockButton.tsx
+++ b/packages/redux-devtools-app/src/components/buttons/LockButton.tsx
@@ -8,7 +8,6 @@ import { Dispatch } from 'redux';
 type DispatchProps = ReturnType<typeof mapDispatchToProps>;
 interface OwnProps {
   locked: boolean | undefined;
-  disabled: boolean;
 }
 type Props = DispatchProps & OwnProps;
 
@@ -21,7 +20,6 @@ class LockButton extends Component<Props> {
     return (
       <Button
         tooltipPosition="bottom"
-        disabled={this.props.disabled}
         mark={this.props.locked && 'base0D'}
         title={this.props.locked ? 'Unlock changes' : 'Lock changes'}
         onClick={this.props.lockChanges}


### PR DESCRIPTION
Currently the lock button is disabled if the app doesn't think it's talking to a Redux store - which is decided here: https://github.com/reduxjs/redux-devtools/blob/f019024b21e119f6e123bd1f9e2d815d295dfde6/packages/redux-devtools-app/src/reducers/instances.ts#L280

There doesn't seem to be a reason stated for this, and stores other than Redux can certainly implement locking, so I think it would be good to enable this. It's still hidden based on the feature option, which defaults to only being true if it's a Redux store: 
https://github.com/reduxjs/redux-devtools/blob/f019024b21e119f6e123bd1f9e2d815d295dfde6/packages/redux-devtools-app/src/reducers/instances.ts#L290