### PR TITLE
Avoid auto-selecting instance in iFrames

### DIFF
--- a/.changeset/fluffy-steaks-promise.md
+++ b/.changeset/fluffy-steaks-promise.md
@@ -1,0 +1,5 @@
+---
+'remotedev-redux-devtools-extension': patch
+---
+
+Avoid auto-selecting instance with iFrames

--- a/extension/src/window/store/instanceSelectorMiddleware.ts
+++ b/extension/src/window/store/instanceSelectorMiddleware.ts
@@ -13,7 +13,16 @@ function selectInstance(
 ) {
   const instances = store.getState().instances;
   if (instances.current === 'default') return;
-  const connections = instances.connections[tabId];
+
+  const connections = Object.entries(instances.connections).reduce<
+    (string | number)[]
+  >((acc, [key, connections]) => {
+    if (key.startsWith(String(tabId))) {
+      return [...acc, ...connections];
+    }
+    return acc;
+  }, []);
+
   if (connections && connections.length === 1) {
     next({ type: SELECT_INSTANCE, selected: connections[0] });
   }


### PR DESCRIPTION
**Note: First time contributing to this project, open to feedback**

Avoid auto-selecting the outer frame instance when redux exists in iFrame embedded on the page.

Fix: #1000

iFrame has a different tabID than the main frame. The connections are therefore not grouped properly.

Example: 
```
{
  "connections": {
    "<tabId>" ["<firstConnectionID>"],
    "<iFrameTabId>": ["<secondConnectionID>"]
  }
}
```

Should we group those connections under the same key? 
The fix is working but I'm unsure if it's the right solution to the problem.