### PR TITLE
Split large messages sent from background page to devpanel

### DIFF
--- a/.changeset/ninety-files-obey.md
+++ b/.changeset/ninety-files-obey.md
@@ -1,0 +1,5 @@
+---
+'remotedev-redux-devtools-extension': patch
+---
+
+Split large messages sent from background page to devpanel

--- a/extension/src/background/store/apiMiddleware.ts
+++ b/extension/src/background/store/apiMiddleware.ts
@@ -229,21 +229,72 @@ type MonitorAction<S, A extends Action<string>> =
   | UpdateStateAction<S, A>
   | SetPersistAction;
 
+// Chrome message limit is 64 MB, but we're using 32 MB to include other object's parts
+const maxChromeMsgSize = 32 * 1024 * 1024;
+
 function toMonitors<S, A extends Action<string>>(
   action: MonitorAction<S, A>,
   tabId?: string | number,
   verbose?: boolean,
 ) {
-  Object.keys(connections.monitor).forEach((id) => {
-    connections.monitor[id].postMessage(
+  for (const monitorPort of Object.values(connections.monitor)) {
+    monitorPort.postMessage(
       verbose || action.type === 'ERROR' || action.type === SET_PERSIST
         ? action
         : { type: UPDATE_STATE },
     );
-  });
-  Object.keys(connections.panel).forEach((id) => {
-    connections.panel[id].postMessage(action);
-  });
+  }
+
+  for (const panelPort of Object.values(connections.panel)) {
+    try {
+      panelPort.postMessage(action);
+    } catch (err) {
+      if (
+        action.type !== UPDATE_STATE ||
+        err == null ||
+        (err as Error).message !==
+          'Message length exceeded maximum allowed length.'
+      ) {
+        throw err;
+      }
+
+      const splitMessageStart = { split: 'start' };
+      const toSplit: [string, string][] = [];
+      let size = 0;
+      for (const [key, value] of Object.entries(
+        action.request as unknown as Record<string, unknown>,
+      )) {
+        if (typeof value === 'string') {
+          size += value.length;
+          if (size > maxChromeMsgSize) {
+            toSplit.push([key, value]);
+            continue;
+          }
+        }
+
+        splitMessageStart[key] = value;
+      }
+
+      panelPort.postMessage({ ...action, request: splitMessageStart });
+
+      for (let i = 0; i < toSplit.length; i++) {
+        for (let j = 0; j < toSplit[i][1].length; j += maxChromeMsgSize) {
+          panelPort.postMessage({
+            ...action,
+            request: {
+              split: 'chunk',
+              chunk: [
+                toSplit[i][0],
+                toSplit[i][1].substring(j, j + maxChromeMsgSize),
+              ],
+            },
+          });
+        }
+      }
+
+      panelPort.postMessage({ ...action, request: { split: 'end' } });
+    }
+  }
 }
 
 interface ImportMessage {

--- a/extension/src/contentScript/index.ts
+++ b/extension/src/contentScript/index.ts
@@ -16,6 +16,7 @@ import {
   DispatchAction as AppDispatchAction,
 } from '@redux-devtools/app';
 import { LiftedState } from '@redux-devtools/instrument';
+
 const source = '@devtools-extension';
 const pageSource = '@devtools-page';
 // Chrome message limit is 64 MB, but we're using 32 MB to include other object's parts


### PR DESCRIPTION
Related: https://github.com/reduxjs/redux-devtools/issues/1705

Chrome has a maximum message length. We work around this when passing messages between the content script and background page by [splitting messages](https://github.com/zalmoxisus/redux-devtools-extension/pull/582). Since we now need to rely on message passing between the background page and the monitors, we need to add message splitting there as well.

This fixes a preexisting bug where the Redux DevTools don't work for apps with large state when using the DevTools panel in Incognito.