### PR TITLE
Fix releasing Firefox extension

### DIFF
--- a/.changeset/shiny-chicken-hammer.md
+++ b/.changeset/shiny-chicken-hammer.md
@@ -1,0 +1,5 @@
+---
+'remotedev-redux-devtools-extension': patch
+---
+
+Fix releasing Firefox extension

--- a/extension/firefox/manifest.json
+++ b/extension/firefox/manifest.json
@@ -4,12 +4,6 @@
   "manifest_version": 2,
   "description": "Redux Developer Tools for debugging application state changes.",
   "homepage_url": "https://github.com/reduxjs/redux-devtools",
-  "applications": {
-    "gecko": {
-      "id": "extension@redux.devtools",
-      "strict_min_version": "54.0"
-    }
-  },
   "page_action": {
     "default_icon": "img/logo/38x38.png",
     "default_title": "Redux DevTools",

--- a/extension/firefox/manifest.json
+++ b/extension/firefox/manifest.json
@@ -4,6 +4,12 @@
   "manifest_version": 2,
   "description": "Redux Developer Tools for debugging application state changes.",
   "homepage_url": "https://github.com/reduxjs/redux-devtools",
+  "applications": {
+    "gecko": {
+      "id": "extension@redux.devtools",
+      "strict_min_version": "54.0"
+    }
+  },
   "page_action": {
     "default_icon": "img/logo/38x38.png",
     "default_title": "Redux DevTools",

--- a/extension/firefox/manifest.json
+++ b/extension/firefox/manifest.json
@@ -6,8 +6,7 @@
   "homepage_url": "https://github.com/reduxjs/redux-devtools",
   "applications": {
     "gecko": {
-      "id": "extension@redux.devtools",
-      "strict_min_version": "54.0"
+      "id": "extension@redux.devtools"
     }
   },
   "page_action": {


### PR DESCRIPTION
The lowest supported "strict_min_version" is now 58.0.