### PR TITLE
Fix action missing bug when playback speed is set to live

### DIFF
--- a/packages/redux-devtools-slider-monitor/src/SliderMonitor.tsx
+++ b/packages/redux-devtools-slider-monitor/src/SliderMonitor.tsx
@@ -198,12 +198,6 @@ class SliderMonitor<S, A extends Action<string>> extends (PureComponent ||
     const aLoop = () => {
       const replayDiff = Date.now() - currentTimestamp;
       if (replayDiff >= timestampDiff) {
-        this.props.dispatch(
-          jumpToAction(
-            this.props.stagedActionIds[this.props.currentStateIndex + 1],
-          ),
-        );
-
         if (
           this.props.currentStateIndex >=
           this.props.computedStates.length - 1
@@ -212,14 +206,23 @@ class SliderMonitor<S, A extends Action<string>> extends (PureComponent ||
           return;
         }
 
-        timestampDiff = this.getLatestTimestampDiff(
-          this.props.currentStateIndex,
-        );
-        currentTimestamp = Date.now();
+        // Update to check for nextActionId and dispatch it
+        const nextActionId =
+          this.props.stagedActionIds[this.props.currentStateIndex + 1];
+        if (nextActionId !== undefined) {
+          this.props.dispatch(jumpToAction(nextActionId));
 
-        this.setState({
-          timer: requestAnimationFrame(aLoop),
-        });
+          timestampDiff = this.getLatestTimestampDiff(
+            this.props.currentStateIndex,
+          );
+          currentTimestamp = Date.now();
+
+          this.setState({
+            timer: requestAnimationFrame(aLoop),
+          });
+        } else {
+          this.pauseReplay();
+        }
       } else {
         this.setState({
           timer: requestAnimationFrame(aLoop),


### PR DESCRIPTION
This fixes #1751. I've tested it by building it locally and running the extension on Chrome.