### PR TITLE
Send state from background when monitor connects

### DIFF
--- a/.changeset/green-hats-kick.md
+++ b/.changeset/green-hats-kick.md
@@ -1,0 +1,5 @@
+---
+'remotedev-redux-devtools-extension': patch
+---
+
+Send state from background when monitor connects


### PR DESCRIPTION
Fixes part of #1731

It seems that third-party integrations started to depend on this behavior, despite it not being officially supported, so at this point we don't have choice but to support it