### PR TITLE
[Fix] react-json-tree: Handle sparse empty arrays greater than limit

### DIFF
--- a/packages/react-json-tree/src/JSONNestedNode.tsx
+++ b/packages/react-json-tree/src/JSONNestedNode.tsx
@@ -27,7 +27,7 @@ interface Entry {
 }
 
 function isRange(rangeOrEntry: Range | Entry): rangeOrEntry is Range {
-  return (rangeOrEntry as Range).to !== undefined;
+  return (rangeOrEntry as Range)?.to !== undefined;
 }
 
 function renderChildNodes(
@@ -54,6 +54,10 @@ function renderChildNodes(
     from,
     to,
   ).forEach((entry) => {
+    // Don't process null/undefined entries, which can come from sparse arrays
+    if(!entry) {
+      return
+    }
     if (isRange(entry)) {
       childNodes.push(
         <ItemRange


### PR DESCRIPTION
This is one potential fix for https://github.com/reduxjs/redux-devtools/issues/1827

Given an input like:

```js
let sparseArrayBroken = [];
sparseArrayBroken[50] = "this will cause a crash";
<JSONTree data={sparseArrayBroken}/>
```

Currently `getCollectionEntries()` and its `isRange()` call does not properly handle sparse arrays greater than the `limit`. It will try to pass through empty entries to the `isRange()` and subsequent `const { key, value } = entry` destructuring, both of which halt the script.

This PR bypasses the crash and allows the rendering to continue.

There is a separate cosmetic bug that this PR does NOT fix:

- If `limitedEntries` in getCollectionEntries() is not subset, but `limit - 4` === `length - 5`, it will cause a single-item collapsed range
- And if the item(s) in that single-item range are empty, expanding that range will just cause it to disappear
- Probably it doesn't need to be range-ified at all in that case, but that's outside the scope of this PR
