### PR TITLE
Handle api.provided state changes in RTKQ 2.6.2

### DIFF
--- a/.changeset/little-melons-grow.md
+++ b/.changeset/little-melons-grow.md
@@ -1,0 +1,5 @@
+---
+'@redux-devtools/rtk-query-monitor': minor
+---
+
+Handle api.provided state changes in RTKQ 2.6.2

--- a/packages/redux-devtools-rtk-query-monitor/src/selectors.ts
+++ b/packages/redux-devtools-rtk-query-monitor/src/selectors.ts
@@ -6,9 +6,10 @@ import {
   RtkQueryApiState,
   RtkQueryTag,
   SelectorsSource,
-  RtkQueryProvided,
+  RtkQueryProvidedTagsState,
   QueryPreviewTabs,
   RtkResourceInfo,
+  RtkQuery262ProvidedState,
 } from './types';
 import { Comparator, queryComparators } from './utils/comparators';
 import { FilterList, queryListFilters } from './utils/filters';
@@ -216,7 +217,7 @@ export function createInspectorSelectors<S>(): InspectorSelectors<S> {
 
   const selectProvidedOfCurrentQuery: InspectorSelector<
     S,
-    null | RtkQueryProvided
+    null | RtkQueryProvidedTagsState | RtkQuery262ProvidedState
   > = (selectorsSource: SelectorsSource<S>) => {
     return selectApiOfCurrentQuery(selectorsSource)?.provided ?? null;
   };

--- a/packages/redux-devtools-rtk-query-monitor/src/types.ts
+++ b/packages/redux-devtools-rtk-query-monitor/src/types.ts
@@ -1,5 +1,9 @@
 import type { LiftedAction, LiftedState } from '@redux-devtools/core';
-import type { createApi, QueryStatus } from '@reduxjs/toolkit/query';
+import type {
+  createApi,
+  QueryCacheKey,
+  QueryStatus,
+} from '@reduxjs/toolkit/query';
 import type { Action, AnyAction, Dispatch } from '@reduxjs/toolkit';
 import type { ComponentType } from 'react';
 import { base16Themes } from 'react-base16-styling';
@@ -52,7 +56,37 @@ export type RtkMutationState = NonNullable<
 
 export type RtkQueryApiConfig = RtkQueryApiState['config'];
 
-export type RtkQueryProvided = RtkQueryApiState['provided'];
+export type FullTagDescription<TagType> = {
+  type: TagType;
+  id?: number | string;
+};
+
+// This is the actual tags structure, and was the entire `api.provided`
+// field up through 2.6.1
+export type RtkQueryProvidedTagsState = {
+  [x: string]: {
+    [id: string]: QueryCacheKey[];
+    [id: number]: QueryCacheKey[];
+  };
+};
+
+// As of 2.6.2, the `api.provided` field is split into `tags` and `keys` fields,
+// with the old data nested in `tags`.
+export type RtkQuery262ProvidedState = {
+  keys: Record<QueryCacheKey, FullTagDescription<any>[]>;
+  tags: RtkQueryProvidedTagsState;
+};
+
+export function isRtkQuery262Provided(
+  provided: Record<string, unknown>,
+): provided is RtkQuery262ProvidedState {
+  return (
+    'tags' in provided &&
+    'keys' in provided &&
+    typeof provided.tags === 'object' &&
+    typeof provided.keys === 'object'
+  );
+}
 
 export interface ExternalProps<S, A extends Action<string>> {
   dispatch: Dispatch<Action | LiftedAction<S, A, RtkQueryMonitorState>>;


### PR DESCRIPTION
This PR:

- Switches from inferring the type of RTK Query's `api.provided` state field to copying the 2.6.1 types
- Adds the revised state structure types for 2.6.2, which now nest the data as `{keys, tags}`
- Updates the RTKQ processing logic to conditionally use the right tags field, so that it can handle both 2.6.1- and 2.6.2+ without crashing

This should handle the changes in the corresponding RTKQ PR, so that I can actually land and release an RTKQ update:

- https://github.com/reduxjs/redux-toolkit/pull/4910