### PR TITLE
Use Chrome for Testing for Selenium testing

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -16,7 +16,7 @@
     "build:examples": "babel-node examples/buildAll.js",
     "clean": "rimraf dist && rimraf chrome/dist && rimraf edge/dist && rimraf firefox/dist",
     "test:app": "cross-env BABEL_ENV=test jest test/app",
-    "test:chrome": "jest test/chrome",
+    "test:chrome": "cross-env SE_FORCE_BROWSER_DOWNLOAD=true jest test/chrome",
     "build:test:electron:fixture": "webpack --config test/electron/fixture/webpack.config.js",
     "test:electron": "pnpm run build:test:electron:fixture && jest test/electron",
     "test": "pnpm run test:app && pnpm run test:chrome && pnpm run test:electron",

--- a/extension/test/chrome/extension.spec.js
+++ b/extension/test/chrome/extension.spec.js
@@ -13,6 +13,7 @@ describe('Chrome extension', function () {
 
   beforeAll(async () => {
     driver = new webdriver.Builder()
+      .forBrowser(webdriver.Browser.CHROME)
       .setChromeOptions(
         new chrome.Options()
           .setBrowserVersion('stable')

--- a/extension/test/chrome/extension.spec.js
+++ b/extension/test/chrome/extension.spec.js
@@ -13,7 +13,6 @@ describe('Chrome extension', function () {
 
   beforeAll(async () => {
     driver = new webdriver.Builder()
-      .forBrowser(webdriver.Browser.CHROME)
       .setChromeOptions(
         new chrome.Options()
           .setBrowserVersion('stable')


### PR DESCRIPTION
See:

- https://github.com/SeleniumHQ/selenium/issues/15788
- https://groups.google.com/a/chromium.org/g/chromium-extensions/c/aEHdhDZ-V0E/m/UWP4-k32AgAJ
- https://github.com/SeleniumHQ/selenium/issues/12986

It seems like Chrome for Testing is what Chrome is encouraging for this use case, and this is how to enable it in Selenium. There doesn't seem to be a way to enable it via the JS API at the moment.

For future reference, this is how I got Selenium logging working:

```js
logging.installConsoleHandler();
logging.getLogger().setLevel(logging.Level.ALL);
```